### PR TITLE
Add CLAUDE.md for repository guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,27 @@
+# CLAUDE.md for TIL Repository
+
+## Repository Structure
+- Topic-specific directories (aws, git, shell, etc.)
+- Individual TIL entries as Markdown files within topic directories
+
+## Markdown Formatting Conventions
+- Use descriptive filenames in lowercase with underscores (e.g., `git_configure.md`)
+- Start each file with a level 1 or level 2 heading describing the topic
+- Use code blocks with backticks (```) for commands and code snippets
+- Specify language for syntax highlighting where applicable
+- Keep entries concise and focused on a single topic
+
+## File Organization
+- Group related TILs in topic-specific directories
+- Name files descriptively to indicate their content
+- Follow the pattern: `topic/specific_knowledge.md`
+
+## Content Guidelines
+- Focus on practical, actionable information
+- Include command examples where applicable
+- Explain the context or problem being solved
+- Keep entries brief but complete enough to be useful
+- Link to external references when appropriate using [text](URL) format
+
+## Markdown Preview
+- For macOS: `brew install --cask qlmarkdown`


### PR DESCRIPTION
## Summary
- Added CLAUDE.md with repository structure and markdown formatting guidelines
- Document provides content guidelines and file organization conventions for the TIL repo
- Included information about markdown preview tool for macOS

🤖 Generated with Claude Code