### PR TITLE
skills: tmux-state — --help, $PATH install, macOS cwd timer

### DIFF
--- a/skills/tmux-session-persistence/SKILL.md
+++ b/skills/tmux-session-persistence/SKILL.md
@@ -13,7 +13,7 @@ survive a **server kill or reboot**.
 | Option | State | Notes |
 |---|---|---|
 | tmux-resurrect + tmux-continuum | 13.0k / 4.0k stars, last push 2024-08 | De-facto standard. Restores panes, layouts, optionally running programs. Zero code with tpm. |
-| script below | tested | ~35 lines, one TSV file, no deps. Use when other tooling must **read** the state. |
+| script below | tested | ~68 lines, one TSV file, no deps. Use when other tooling must **read** the state. |
 | tmuxp | actively maintained | `tmuxp freeze` → YAML. Good for versioned project layouts. |
 
 Prefer resurrect + continuum unless the state file must be machine-readable.
@@ -30,10 +30,31 @@ set -g @continuum-restore 'on'
 
 ## Script route
 
-`~/.tmux/scripts/tmux-state.sh {save|restore|show}`. State defaults to
-`~/.local/state/tmux/state.tsv` (`TMUX_STATE_FILE` overrides); `TMUX_BIN`
-overrides the binary, which is how you test against a throwaway socket.
-`restore` is idempotent — it only creates what is missing.
+`~/.tmux/scripts/tmux-state.sh {save|restore|show|help}`. State defaults
+to `~/.local/state/tmux/state.tsv` (`TMUX_STATE_FILE` overrides);
+`TMUX_BIN` overrides the binary, which is how you test against a
+throwaway socket. `restore` is idempotent — it only creates what is
+missing, so it is safe to re-run.
+
+Put it on `$PATH` so it is usable as a normal command. The usage text
+derives its own name from `$0`, so the symlink reports `tmux-state`:
+
+```bash
+mkdir -p ~/.local/bin
+ln -sfn ~/.tmux/scripts/tmux-state.sh ~/.local/bin/tmux-state
+tmux-state --help
+```
+
+Restoring after a reboot is two commands, run from **outside** tmux:
+
+```bash
+tmux-state restore
+tmux attach
+```
+
+That rebuilds the session/window skeleton with each window's saved cwd.
+It does **not** restore running programs — that is what resurrect buys
+you and this does not.
 
 ```bash
 #!/usr/bin/env bash
@@ -46,7 +67,36 @@ FMT='#{session_name}	#{window_index}	#{window_name}	#{pane_current_path}'
 
 dump() { $TMUX_BIN list-windows -a -F "$FMT" 2>/dev/null; }
 
+usage() {
+  cat <<EOF
+usage: ${0##*/} {save|restore|show|help}
+
+Persist tmux sessions and windows across a server restart.
+
+commands:
+  save      snapshot live sessions/windows to the state file (default)
+  restore   recreate any saved session/window that is missing; idempotent
+  show      print live state to stdout without writing the state file
+  help      this message
+
+state file:
+  $STATE_FILE
+  TSV: session <TAB> window_index <TAB> window_name <TAB> cwd
+
+environment:
+  TMUX_STATE_FILE   state file path (default ~/.local/state/tmux/state.tsv)
+  TMUX_BIN          tmux binary/socket (default: tmux); set to
+                    "tmux -L test" to work against a throwaway server
+
+notes:
+  restore only creates what is missing, so it is safe to re-run. It
+  restores the session/window skeleton with cwds, not running programs.
+  save never overwrites the state file with an empty dump.
+EOF
+}
+
 case "${1:-save}" in
+  -h|--help|help) usage ;;
   show) dump ;;
   save)
     mkdir -p "$(dirname "$STATE_FILE")"
@@ -73,7 +123,7 @@ case "${1:-save}" in
       fi
     done < "$STATE_FILE"
     ;;
-  *) echo "usage: $0 {save|restore|show}" >&2; exit 2 ;;
+  *) usage >&2; exit 2 ;;
 esac
 ```
 
@@ -94,6 +144,65 @@ set-hook -g session-closed  'run-shell -b "~/.tmux/scripts/tmux-state.sh save"'
 set-hook -g client-detached 'run-shell -b "~/.tmux/scripts/tmux-state.sh save"'
 ```
 
+## Periodic cwd capture
+
+cwd changes are not hookable, so the hooks above only capture cwd at
+window and session boundaries. If live cwd tracking matters, add a ~60s
+timer running `save`.
+
+Linux, `~/.config/systemd/user/tmux-state.timer` plus a matching
+`tmux-state.service` running the script:
+
+```ini
+[Unit]
+Description=Snapshot tmux session state
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=1min
+
+[Install]
+WantedBy=timers.target
+```
+
+macOS has no systemd — use a launchd agent at
+`~/Library/LaunchAgents/tmux-state.plist`, then
+`launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/tmux-state.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>tmux-state</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Users/YOU/.tmux/scripts/tmux-state.sh</string>
+    <string>save</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key><string>/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    <key>HOME</key><string>/Users/YOU</string>
+    <key>TMUX_BIN</key><string>/opt/homebrew/bin/tmux</string>
+  </dict>
+  <key>StartInterval</key><integer>60</integer>
+  <key>RunAtLoad</key><true/>
+  <key>ProcessType</key><string>Background</string>
+  <key>StandardErrorPath</key><string>/Users/YOU/Library/Logs/tmux-state.err.log</string>
+</dict>
+</plist>
+```
+
+launchd gives the job a bare `PATH` with no Homebrew, so pin `TMUX_BIN`
+to an absolute path. Force a run with
+`launchctl kickstart -p gui/$(id -u)/tmux-state`; disable with
+`launchctl bootout gui/$(id -u)/tmux-state`.
+
+To prove the timer really reaches the live server — rather than
+silently saving nothing — delete the state file, kick the job, and
+confirm it comes back populated.
+
 ## Verify (executable)
 
 Never test against the live server — use a separate socket:
@@ -111,7 +220,7 @@ tmux -L statetest kill-server
 
 ## Gotchas
 
-Verified on tmux 3.4.
+Verified on tmux 3.4 and 3.7b.
 
 - **`after-kill-window` does not exist.** tmux 3.4 rejects it with
   `invalid option`, breaking config load. The kill-side hook is
@@ -120,6 +229,11 @@ Verified on tmux 3.4.
   first window is created internally, not via the `new-window` command.
   `window-linked` covers both, plus `move-window` and `link-window`.
 - **`session-created` is redundant** once `window-linked` is set.
+- **`window-renamed` is a window-scoped hook.** `set-hook -g` sets it
+  correctly, but it lands in the global *window* option table, so
+  `show-hooks -g` does not list it — only `show-hooks -gw` does. The
+  other four hooks show under `-g`. Checking only `-g` makes a working
+  hook look like it failed to register.
 - **Hooks fire after the change lands** — a save triggered by
   `window-unlinked` does not see the killed window. No sleep needed.
 - **Hooks can fire twice concurrently.** Writing `$STATE_FILE.$$` then
@@ -130,7 +244,13 @@ Verified on tmux 3.4.
 - **A top-level `new-session` in `~/.tmux.conf`** creates a phantom
   session on a fresh server that collides with restore
   (`duplicate session: 0`). A naive `set -e` loop aborts on it and
-  restores nothing.
-- **cwd changes are not hookable.** Add a ~60s systemd user timer running
-  `save` if live cwd tracking matters; otherwise cwd is captured at
-  window and session boundaries.
+  restores nothing. The `has-session` guard here tolerates it, but the
+  phantom session gets saved and re-created forever.
+- **tmux puts its socket in `/tmp/tmux-$UID`, not `$TMPDIR`** — unless
+  `TMUX_TMPDIR` is set. This is what lets a launchd agent find the live
+  server at all, since agents get a different `$TMPDIR` than your shell.
+  Set `TMUX_TMPDIR` in a shell rc and the timer silently dumps nothing;
+  the empty-dump guard then keeps the stale file, so state just freezes
+  with no error. Export it to the timer too, or don't set it.
+- **cwd changes are not hookable.** See *Periodic cwd capture* above;
+  otherwise cwd is captured at window and session boundaries.


### PR DESCRIPTION
Re-verified `tmux-session-persistence` end-to-end on **tmux 3.7b** (the note claimed 3.4 only) while applying it to a live macOS host. Everything in the note held up; these are the gaps it left.

## Script

- `usage()` reachable as `help`, `-h`, `--help`, and reused for the bad-arg path (exit 2, usage to stderr).
- Name comes from `$0` and the state path is printed resolved, so it self-documents when symlinked.
- Embedded code block is spliced from the working script, so it is byte-identical to what was actually tested — tabs in `FMT` included.

## Docs

- Installing on `$PATH` as `tmux-state`.
- The restore path spelled out (`tmux-state restore; tmux attach`), plus the limitation that only the skeleton and cwds come back, not running programs. That was implied but never stated.
- New **Periodic cwd capture** section. The old note disposed of this in one clause pointing at a systemd timer; macOS has no systemd, so there is now a launchd agent alongside the systemd unit.

## New gotchas

Both of these cost real time:

- **`window-renamed` is window-scoped.** `set-hook -g` sets it correctly but it lands in the global *window* table, so `show-hooks -g` does not list it — only `-gw` does. A working hook looks like it failed to register.
- **tmux sockets live in `/tmp/tmux-$UID`, not `$TMPDIR`.** This is the only reason a launchd agent finds the live server, since agents get a different `$TMPDIR` than your shell. Set `TMUX_TMPDIR` in a shell rc without exporting it to the timer and every save dumps nothing; the empty-dump guard then keeps the stale file, so state freezes silently with no error.

## Verification

- `./til validate` — all entries valid
- `python3 -m unittest test_til.py` — OK
- `./til execute tmux-session-persistence Verify` — passes; restores `alpha:0 edit /tmp`, `alpha:1 logs /var/log`
- launchd agent confirmed to reach the live server by deleting the state file, kickstarting the job, and watching it repopulate